### PR TITLE
Add Jest integration test suite and achieve 100% coverage

### DIFF
--- a/__tests__/components/ui/FilterButtonsGrid.test.tsx
+++ b/__tests__/components/ui/FilterButtonsGrid.test.tsx
@@ -17,6 +17,7 @@ describe("FilterButtonsGrid", () => {
         onFilterSelect={onFilterSelect}
       />,
     );
+    
     expect(screen.getAllByRole("button")).toHaveLength(filters.length);
   });
 
@@ -27,6 +28,7 @@ describe("FilterButtonsGrid", () => {
         onFilterSelect={onFilterSelect}
       />,
     );
+
     expect(screen.getByRole("button", { name: "Cats" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Dogs" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Nature" })).toBeInTheDocument();
@@ -36,6 +38,7 @@ describe("FilterButtonsGrid", () => {
     render(
       <FilterButtonsGrid imageButtons={[]} onFilterSelect={onFilterSelect} />,
     );
+
     expect(screen.queryAllByRole("button")).toHaveLength(0);
   });
 
@@ -47,22 +50,26 @@ describe("FilterButtonsGrid", () => {
         onFilterSelect={onFilterSelect}
       />,
     );
+    
     await user.click(screen.getByRole("button", { name: "Cats" }));
+
     expect(onFilterSelect).toHaveBeenCalledTimes(1);
     expect(onFilterSelect).toHaveBeenCalledWith("cats");
   });
 
   it("calls onFilterSelect independently for each button", async () => {
     const user = userEvent.setup();
+
     render(
       <FilterButtonsGrid
         imageButtons={filters}
         onFilterSelect={onFilterSelect}
       />,
     );
+
     await user.click(screen.getByRole("button", { name: "Dogs" }));
     await user.click(screen.getByRole("button", { name: "Nature" }));
-    
+
     expect(onFilterSelect).toHaveBeenCalledTimes(2);
     expect(onFilterSelect).toHaveBeenNthCalledWith(1, "dogs");
     expect(onFilterSelect).toHaveBeenNthCalledWith(2, "nature");

--- a/__tests__/components/ui/ImageCard.test.tsx
+++ b/__tests__/components/ui/ImageCard.test.tsx
@@ -43,6 +43,7 @@ afterEach(() => {
 describe("ImageCard", () => {
   it("renders the image with alt_description", () => {
     render(<ImageCard {...baseProps} />);
+    
     expect(screen.getByRole("img")).toHaveAttribute(
       "alt",
       baseProps.image.alt_description,
@@ -53,11 +54,13 @@ describe("ImageCard", () => {
     render(
       <ImageCard {...baseProps} image={makeImage({ alt_description: "" })} />,
     );
+
     expect(screen.getByRole("img")).toHaveAttribute("alt", "image");
   });
 
   it("uses urls.regular as the image src", () => {
     render(<ImageCard {...baseProps} />);
+
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
       baseProps.image.urls.regular,
@@ -66,6 +69,7 @@ describe("ImageCard", () => {
 
   it("wraps the image in a link to links.html", () => {
     render(<ImageCard {...baseProps} />);
+
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
       baseProps.image.links.html,
@@ -74,6 +78,7 @@ describe("ImageCard", () => {
 
   it("passes priority to Image", () => {
     render(<ImageCard {...baseProps} priority={true} />);
+
     expect(MockImage.mock.calls[0][0]).toHaveProperty("priority", true);
   });
 
@@ -84,7 +89,7 @@ describe("ImageCard", () => {
         image={makeImage({ color: null as unknown as string })}
       />,
     );
-    
+
     expect(MockImage.mock.calls[0][0]).toHaveProperty("style", {
       backgroundColor: undefined,
     });
@@ -92,19 +97,24 @@ describe("ImageCard", () => {
 
   it("renders ImageDetailsDisplay", () => {
     render(<ImageCard {...baseProps} />);
+
     expect(screen.getByTestId("image-details-display")).toBeInTheDocument();
   });
 
   describe("image load error", () => {
     it("shows error message when image fails to load", () => {
       render(<ImageCard {...baseProps} />);
+
       fireEvent.error(screen.getByRole("img"));
+
       expect(screen.getByText("Image failed to load.")).toBeInTheDocument();
     });
 
     it("removes the image after load error", () => {
       render(<ImageCard {...baseProps} />);
+
       fireEvent.error(screen.getByRole("img"));
+
       expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
   });

--- a/__tests__/components/ui/ImageCard.test.tsx
+++ b/__tests__/components/ui/ImageCard.test.tsx
@@ -77,6 +77,19 @@ describe("ImageCard", () => {
     expect(MockImage.mock.calls[0][0]).toHaveProperty("priority", true);
   });
 
+  it("passes undefined backgroundColor when image color is null", () => {
+    render(
+      <ImageCard
+        {...baseProps}
+        image={makeImage({ color: null as unknown as string })}
+      />,
+    );
+    
+    expect(MockImage.mock.calls[0][0]).toHaveProperty("style", {
+      backgroundColor: undefined,
+    });
+  });
+
   it("renders ImageDetailsDisplay", () => {
     render(<ImageCard {...baseProps} />);
     expect(screen.getByTestId("image-details-display")).toBeInTheDocument();

--- a/__tests__/components/ui/ImageGrid.test.tsx
+++ b/__tests__/components/ui/ImageGrid.test.tsx
@@ -32,7 +32,12 @@ afterEach(() => {
 
 describe("ImageGrid", () => {
   it("renders an ImageCard for each image", () => {
-    const images = [makeImage({ id: "a" }), makeImage({ id: "b" }), makeImage({ id: "c" })];
+    const images = [
+      makeImage({ id: "a" }),
+      makeImage({ id: "b" }),
+      makeImage({ id: "c" }),
+    ];
+    
     render(<ImageGrid {...baseProps} images={images} />);
     expect(screen.getAllByTestId(/^image-card-/)).toHaveLength(3);
   });
@@ -69,9 +74,18 @@ describe("ImageGrid", () => {
 
       render(<ImageGrid {...baseProps} images={images} />);
 
-      expect(screen.getByTestId("image-card-a")).toHaveAttribute("data-priority", "true");
-      expect(screen.getByTestId("image-card-b")).toHaveAttribute("data-priority", "true");
-      expect(screen.getByTestId("image-card-c")).toHaveAttribute("data-priority", "true");
+      expect(screen.getByTestId("image-card-a")).toHaveAttribute(
+        "data-priority",
+        "true",
+      );
+      expect(screen.getByTestId("image-card-b")).toHaveAttribute(
+        "data-priority",
+        "true",
+      );
+      expect(screen.getByTestId("image-card-c")).toHaveAttribute(
+        "data-priority",
+        "true",
+      );
     });
 
     it("sets priority=false for images beyond the first 3", () => {
@@ -83,7 +97,10 @@ describe("ImageGrid", () => {
       ];
 
       render(<ImageGrid {...baseProps} images={images} />);
-      expect(screen.getByTestId("image-card-d")).toHaveAttribute("data-priority", "false");
+      expect(screen.getByTestId("image-card-d")).toHaveAttribute(
+        "data-priority",
+        "false",
+      );
     });
   });
 
@@ -98,8 +115,15 @@ describe("ImageGrid", () => {
       />,
     );
     const calls = MockImageCard.mock.calls;
+
+    expect(calls[0][0]).toMatchObject({
+      activeMode: "likes",
+      activeUsername: "jane",
+    });
     
-    expect(calls[0][0]).toMatchObject({ activeMode: "likes", activeUsername: "jane" });
-    expect(calls[1][0]).toMatchObject({ activeMode: "likes", activeUsername: "jane" });
+    expect(calls[1][0]).toMatchObject({
+      activeMode: "likes",
+      activeUsername: "jane",
+    });
   });
 });

--- a/__tests__/components/ui/PaginationControls.test.tsx
+++ b/__tests__/components/ui/PaginationControls.test.tsx
@@ -70,8 +70,11 @@ describe("PaginationControls", () => {
 
     it("calls setPage with page - 1 when clicked", async () => {
       const user = userEvent.setup();
+
       renderControls({ page: 3 });
+
       await user.click(screen.getByRole("button", { name: "Previous" }));
+
       expect(setPage).toHaveBeenCalledWith(2);
     });
   });
@@ -103,6 +106,7 @@ describe("PaginationControls", () => {
   describe("page input", () => {
     it("shows the current page", () => {
       renderControls({ page: 5 });
+
       expect(
         screen.getByRole("spinbutton", { name: "Page Number Input" }),
       ).toHaveValue(5);
@@ -110,6 +114,7 @@ describe("PaginationControls", () => {
 
     it("syncs with page prop changes", () => {
       const { rerender } = renderControls({ page: 1 });
+
       rerender(
         <PaginationControls
           loading={false}
@@ -118,6 +123,7 @@ describe("PaginationControls", () => {
           totalPages={10}
         />,
       );
+      
       expect(
         screen.getByRole("spinbutton", { name: "Page Number Input" }),
       ).toHaveValue(5);
@@ -166,7 +172,7 @@ describe("PaginationControls", () => {
       const user = userEvent.setup();
 
       renderControls({ page: 1, totalPages: 10 });
-      
+
       const input = screen.getByRole("spinbutton", {
         name: "Page Number Input",
       });
@@ -213,7 +219,7 @@ describe("PaginationControls", () => {
 
     it("Increase button is disabled at total pages", () => {
       renderControls({ page: 10, totalPages: 10 });
-      
+
       expect(
         screen.getByRole("button", { name: "Increase page" }),
       ).toBeDisabled();

--- a/__tests__/components/ui/SearchInput.test.tsx
+++ b/__tests__/components/ui/SearchInput.test.tsx
@@ -89,7 +89,7 @@ describe("SearchInput", () => {
 
       await user.click(screen.getByRole("searchbox"));
       await user.keyboard("{Enter}");
-      
+
       expect(baseProps.onSubmit).toHaveBeenCalledTimes(1);
     });
   });

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -506,6 +506,46 @@ describe("Home page integration", () => {
     });
   });
 
+  it("resets to page 1 when per-page is changed while on page 2", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 3);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Results per page" }),
+      "18 results",
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("per_page=18"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining("page=1"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("resets to page 1 and fetches when a new search is submitted from page 2", async () => {
     const image = makeImage({ id: "1" });
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -506,6 +506,26 @@ describe("Home page integration", () => {
     });
   });
 
+  it("shows 'Relevance' label after toggling sort order twice", async () => {
+    mockFetch();
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.click(screen.getByRole("button", { name: "Relevance" }));
+
+    expect(
+      screen.getByRole("button", { name: "Latest" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Latest" }));
+
+    expect(
+      screen.getByRole("button", { name: "Relevance" }),
+    ).toBeInTheDocument();
+  });
+
   it("shows 'Light Mode' label after clicking the dark mode toggle", async () => {
     mockFetch();
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -506,6 +506,24 @@ describe("Home page integration", () => {
     });
   });
 
+  it("shows 'Light Mode' label after clicking the dark mode toggle", async () => {
+    mockFetch();
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    expect(
+      screen.getByRole("button", { name: "Dark Mode" }),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Dark Mode" }));
+
+    expect(
+      screen.getByRole("button", { name: "Light Mode" }),
+    ).toBeInTheDocument();
+  });
+
   it("fetches the previous page when the Previous button is clicked", async () => {
     const image = makeImage({ id: "1" });
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -506,6 +506,47 @@ describe("Home page integration", () => {
     });
   });
 
+  it("resets to page 1 and fetches when a filter button is clicked from page 2", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 3);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(`^${imageButtons[0]}$`, "i"),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining(`query=${imageButtons[0]}`),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining("page=1"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("resets to page 1 when per-page is changed while on page 2", async () => {
     const image = makeImage({ id: "1" });
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -54,11 +54,11 @@ describe("Home page integration", () => {
 
   it("shows images and pagination after a successful search", async () => {
     const image = makeImage({ id: "1", alt_description: "mountain lake" });
-    
+
     mockFetch([image], 3);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "nature");
@@ -69,7 +69,7 @@ describe("Home page integration", () => {
     });
 
     expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
-    
+
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringContaining("/api/images?query=nature"),
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
@@ -82,9 +82,9 @@ describe("Home page integration", () => {
       statusText: "Internal Server Error",
       json: () => Promise.resolve({ message: "Something went wrong" }),
     } as unknown as Response);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "nature");
@@ -97,9 +97,9 @@ describe("Home page integration", () => {
 
   it("shows 'No results found.' when the API returns an empty array", async () => {
     mockFetch([], 0);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "xkcdzzz");
@@ -112,11 +112,11 @@ describe("Home page integration", () => {
 
   it("fetches with filter query when a category button is clicked", async () => {
     const image = makeImage({ id: "1" });
-    
+
     mockFetch([image], 1);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.click(
@@ -135,11 +135,11 @@ describe("Home page integration", () => {
 
   it("fetches page 2 when the Next button is clicked", async () => {
     const image = makeImage({ id: "1" });
-    
+
     mockFetch([image], 3);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "nature");
@@ -161,11 +161,11 @@ describe("Home page integration", () => {
 
   it("resets to initial state when the title is clicked", async () => {
     const image = makeImage({ id: "1" });
-    
+
     mockFetch([image], 1);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "nature");
@@ -180,7 +180,7 @@ describe("Home page integration", () => {
     expect(
       screen.getByText("Search for images above to get started."),
     ).toBeInTheDocument();
-    
+
     expect(screen.queryByAltText("a test image")).not.toBeInTheDocument();
   });
 
@@ -635,9 +635,7 @@ describe("Home page integration", () => {
 
     await user.click(screen.getByRole("button", { name: "Relevance" }));
 
-    expect(
-      screen.getByRole("button", { name: "Latest" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Latest" })).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Latest" }));
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -1,0 +1,219 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Home from "@/app/page";
+import { makeImage } from "../fixtures/makeImage";
+import { imageButtons } from "@/app/utils/constants";
+import type { ImageDetails } from "@/app/models/ImageDetails";
+
+// matchMedia is not implemented in jsdom.
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+function mockFetch(results: ImageDetails[] = [], totalPages = 0) {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve({ results, total_pages: totalPages }),
+  } as unknown as Response);
+}
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Home page integration", () => {
+  it("renders initial state without calling fetch", () => {
+    mockFetch();
+
+    render(<Home />);
+
+    expect(
+      screen.getByRole("heading", { name: "Image Search" }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByRole("searchbox")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Search for images above to get started."),
+    ).toBeInTheDocument();
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("shows images and pagination after a successful search", async () => {
+    const image = makeImage({ id: "1", alt_description: "mountain lake" });
+    
+    mockFetch([image], 3);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("mountain lake")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/images?query=nature"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("shows an error message when the API returns an error", async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({ message: "Something went wrong" }),
+    } as unknown as Response);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'No results found.' when the API returns an empty array", async () => {
+    mockFetch([], 0);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "xkcdzzz");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("No results found.")).toBeInTheDocument();
+    });
+  });
+
+  it("fetches with filter query when a category button is clicked", async () => {
+    const image = makeImage({ id: "1" });
+    
+    mockFetch([image], 1);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(`^${imageButtons[0]}$`, "i"),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/images?query=${imageButtons[0]}`),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("fetches page 2 when the Next button is clicked", async () => {
+    const image = makeImage({ id: "1" });
+    
+    mockFetch([image], 3);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("page=2"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("resets to initial state when the title is clicked", async () => {
+    const image = makeImage({ id: "1" });
+    
+    mockFetch([image], 1);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Image Search" }));
+
+    expect(
+      screen.getByText("Search for images above to get started."),
+    ).toBeInTheDocument();
+    
+    expect(screen.queryByAltText("a test image")).not.toBeInTheDocument();
+  });
+
+  it("switches to user photos mode when 'See More Photos' is clicked", async () => {
+    const image = makeImage({
+      id: "1",
+      user: { ...makeImage().user, username: "johndoe", name: "John Doe" },
+    });
+    
+    mockFetch([image], 1);
+    
+    const user = userEvent.setup();
+    
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    mockFetch([image], 2);
+    
+    await user.click(
+      screen.getByRole("button", { name: "See More Photos by John Doe" }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/api/users/johndoe/photos"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+});

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -506,6 +506,45 @@ describe("Home page integration", () => {
     });
   });
 
+  it("resets to page 1 and fetches when a new search is submitted from page 2", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 3);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 1 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.clear(screen.getByRole("searchbox"));
+    await user.type(screen.getByRole("searchbox"), "mountains");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("query=mountains"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+
+    expect(global.fetch).toHaveBeenLastCalledWith(
+      expect.stringContaining("page=1"),
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
   it("shows 'Relevance' label after toggling sort order twice", async () => {
     mockFetch();
 

--- a/__tests__/integration/page.test.tsx
+++ b/__tests__/integration/page.test.tsx
@@ -189,11 +189,11 @@ describe("Home page integration", () => {
       id: "1",
       user: { ...makeImage().user, username: "johndoe", name: "John Doe" },
     });
-    
+
     mockFetch([image], 1);
-    
+
     const user = userEvent.setup();
-    
+
     render(<Home />);
 
     await user.type(screen.getByRole("searchbox"), "nature");
@@ -204,7 +204,7 @@ describe("Home page integration", () => {
     });
 
     mockFetch([image], 2);
-    
+
     await user.click(
       screen.getByRole("button", { name: "See More Photos by John Doe" }),
     );
@@ -212,6 +212,327 @@ describe("Home page integration", () => {
     await waitFor(() => {
       expect(global.fetch).toHaveBeenLastCalledWith(
         expect.stringContaining("/api/users/johndoe/photos"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("switches to user likes mode when 'Liked Photos' is clicked", async () => {
+    const image = makeImage({
+      id: "1",
+      user: { ...makeImage().user, username: "johndoe", name: "John Doe" },
+    });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    mockFetch([image], 2);
+
+    await user.click(
+      screen.getByRole("button", { name: "Liked Photos by John Doe" }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/api/users/johndoe/likes"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("switches to user collections mode when 'Collections' is clicked", async () => {
+    const image = makeImage({
+      id: "1",
+      user: {
+        ...makeImage().user,
+        username: "johndoe",
+        name: "John Doe",
+        total_collections: 3,
+      },
+    });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument();
+    });
+
+    mockFetch([image], 2);
+
+    await user.click(
+      screen.getByRole("button", { name: "Collections by John Doe" }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("/api/users/johndoe/collections"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("disables the search input and button while a fetch is in-flight", async () => {
+    let resolveFetch!: (value: Response) => void;
+
+    global.fetch = jest.fn().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(screen.getByRole("button", { name: "Search" })).toBeDisabled();
+    expect(screen.getByRole("searchbox")).toBeDisabled();
+
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ results: [], total_pages: 0 }),
+    } as unknown as Response);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Search" })).not.toBeDisabled();
+    });
+
+    expect(screen.getByRole("searchbox")).not.toBeDisabled();
+  });
+
+  it("does not fetch when the search form is submitted with an empty query", async () => {
+    mockFetch();
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches random photos when random mode is on and a filter is clicked", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 0);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.click(screen.getByRole("button", { name: /random/i }));
+
+    await user.click(
+      screen.getByRole("button", {
+        name: new RegExp(`^${imageButtons[0]}$`, "i"),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `/api/photos/random?count=12&query=${imageButtons[0]}`,
+        ),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("includes order_by=latest in the URL after toggling sort order", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Relevance" }));
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("order_by=latest"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("re-fetches with updated per_page when the per-page selector changes", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Results per page" }),
+      "18 results",
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("per_page=18"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("includes color in the URL after selecting a color filter and searching", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Color filter" }),
+      "Blue",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("color=blue"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("re-fetches with updated lang when the language selector changes", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 1);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.selectOptions(
+      screen.getByRole("combobox", { name: "Language" }),
+      "French",
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("lang=fr"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("navigates to a specific page using the Go button", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 5);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    const pageInput = screen.getByRole("spinbutton", {
+      name: "Page Number Input",
+    });
+
+    await user.clear(pageInput);
+    await user.type(pageInput, "3");
+    await user.click(screen.getByRole("button", { name: "Go" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("&page=3&"),
+        expect.objectContaining({ signal: expect.any(AbortSignal) }),
+      );
+    });
+  });
+
+  it("fetches the previous page when the Previous button is clicked", async () => {
+    const image = makeImage({ id: "1" });
+
+    mockFetch([image], 3);
+
+    const user = userEvent.setup();
+
+    render(<Home />);
+
+    await user.type(screen.getByRole("searchbox"), "nature");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => {
+      expect(screen.getByAltText("a test image")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Page 2 of 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Previous" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        expect.stringContaining("&page=1&"),
         expect.objectContaining({ signal: expect.any(AbortSignal) }),
       );
     });

--- a/__tests__/unit/api/images/route.test.ts
+++ b/__tests__/unit/api/images/route.test.ts
@@ -126,6 +126,21 @@ describe("GET /api/images — upstream responses", () => {
     expect(body.message).toContain("Rate limit");
   });
 
+  it("returns the status code with a generic message when upstream returns an unknown error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 418,
+    } as unknown as Response);
+
+    const res = await GET(makeRequest({ query: "cats" }));
+
+    expect(res.status).toBe(418);
+    
+    expect(await res.json()).toEqual({
+      message: "Unsplash API error (418).",
+    });
+  });
+
   it("returns 500 when fetch throws a network error", async () => {
     jest
       .spyOn(global, "fetch")

--- a/__tests__/unit/api/images/route.test.ts
+++ b/__tests__/unit/api/images/route.test.ts
@@ -74,7 +74,7 @@ describe("GET /api/images — input validation", () => {
 describe("GET /api/images — missing API key", () => {
   it("returns 500 when UNSPLASH_KEY is not set", async () => {
     delete process.env["UNSPLASH_KEY"];
-    
+
     const res = await GET(makeRequest({ query: "cats" }));
 
     expect(res.status).toBe(500);
@@ -135,7 +135,7 @@ describe("GET /api/images — upstream responses", () => {
     const res = await GET(makeRequest({ query: "cats" }));
 
     expect(res.status).toBe(418);
-    
+
     expect(await res.json()).toEqual({
       message: "Unsplash API error (418).",
     });

--- a/__tests__/unit/api/photos/random/route.test.ts
+++ b/__tests__/unit/api/photos/random/route.test.ts
@@ -95,7 +95,9 @@ describe("GET /api/photos/random — upstream responses", () => {
       status: 401,
     } as unknown as Response);
 
-    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     const res = await GET(makeRequest());
 
@@ -112,7 +114,7 @@ describe("GET /api/photos/random — upstream responses", () => {
     const res = await GET(makeRequest());
 
     expect(res.status).toBe(418);
-    
+
     expect(await res.json()).toEqual({
       message: "Unsplash API error (418).",
     });

--- a/__tests__/unit/api/photos/random/route.test.ts
+++ b/__tests__/unit/api/photos/random/route.test.ts
@@ -89,6 +89,35 @@ describe("GET /api/photos/random — upstream responses", () => {
     expect(body.total_pages).toBe(0);
   });
 
+  it("returns 401 with key-revoked message and logs an error when upstream returns 401", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    } as unknown as Response);
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(401);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("401"));
+  });
+
+  it("returns the status code with a generic message when upstream returns an unknown error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 418,
+    } as unknown as Response);
+
+    const res = await GET(makeRequest());
+
+    expect(res.status).toBe(418);
+    
+    expect(await res.json()).toEqual({
+      message: "Unsplash API error (418).",
+    });
+  });
+
   it("returns 429 with rate-limit message when upstream returns 429", async () => {
     jest.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: false,

--- a/__tests__/unit/api/users/[username]/collections/route.test.ts
+++ b/__tests__/unit/api/users/[username]/collections/route.test.ts
@@ -165,7 +165,9 @@ describe("GET /api/users/:username/collections — upstream responses", () => {
       ok: false,
       status: 401,
     } as unknown as Response);
-    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     const res = await GET(makeRequest(), makeParams());
 

--- a/__tests__/unit/api/users/[username]/collections/route.test.ts
+++ b/__tests__/unit/api/users/[username]/collections/route.test.ts
@@ -160,6 +160,33 @@ describe("GET /api/users/:username/collections — upstream responses", () => {
     expect(body.message).toContain("janedoe");
   });
 
+  it("returns 401 with key-revoked message and logs an error when upstream returns 401", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    } as unknown as Response);
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(401);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("401"));
+  });
+
+  it("returns the status code with a generic message when upstream returns an unknown error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 418,
+    } as unknown as Response);
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(418);
+    expect(await res.json()).toEqual({
+      message: "Unsplash API error (418).",
+    });
+  });
+
   it("returns 429 with rate-limit message when upstream returns 429", async () => {
     jest.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: false,

--- a/__tests__/unit/api/users/[username]/likes/route.test.ts
+++ b/__tests__/unit/api/users/[username]/likes/route.test.ts
@@ -117,6 +117,35 @@ describe("GET /api/users/:username/likes — upstream responses", () => {
     expect(body.message).toContain("janedoe");
   });
 
+  it("returns 401 with key-revoked message and logs an error when upstream returns 401", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    } as unknown as Response);
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(401);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("401"));
+  });
+
+  it("returns the status code with a generic message when upstream returns an unknown error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 418,
+    } as unknown as Response);
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(418);
+    
+    expect(await res.json()).toEqual({
+      message: "Unsplash API error (418).",
+    });
+  });
+
   it("returns 429 with rate-limit message when upstream returns 429", async () => {
     jest.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: false,

--- a/__tests__/unit/api/users/[username]/likes/route.test.ts
+++ b/__tests__/unit/api/users/[username]/likes/route.test.ts
@@ -123,7 +123,9 @@ describe("GET /api/users/:username/likes — upstream responses", () => {
       status: 401,
     } as unknown as Response);
 
-    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     const res = await GET(makeRequest(), makeParams());
 
@@ -140,7 +142,7 @@ describe("GET /api/users/:username/likes — upstream responses", () => {
     const res = await GET(makeRequest(), makeParams());
 
     expect(res.status).toBe(418);
-    
+
     expect(await res.json()).toEqual({
       message: "Unsplash API error (418).",
     });

--- a/__tests__/unit/api/users/[username]/photos/route.test.ts
+++ b/__tests__/unit/api/users/[username]/photos/route.test.ts
@@ -115,6 +115,34 @@ describe("GET /api/users/:username/photos — upstream responses", () => {
     expect(body.message).toContain("janedoe");
   });
 
+  it("returns 401 with key-revoked message and logs an error when upstream returns 401", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    } as unknown as Response);
+    
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(401);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("401"));
+  });
+
+  it("returns the status code with a generic message when upstream returns an unknown error", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: false,
+      status: 418,
+    } as unknown as Response);
+
+    const res = await GET(makeRequest(), makeParams());
+
+    expect(res.status).toBe(418);
+    expect(await res.json()).toEqual({
+      message: "Unsplash API error (418).",
+    });
+  });
+
   it("returns 429 with rate-limit message when upstream returns 429", async () => {
     jest.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: false,

--- a/__tests__/unit/api/users/[username]/photos/route.test.ts
+++ b/__tests__/unit/api/users/[username]/photos/route.test.ts
@@ -120,8 +120,10 @@ describe("GET /api/users/:username/photos — upstream responses", () => {
       ok: false,
       status: 401,
     } as unknown as Response);
-    
-    const consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+
+    const consoleSpy = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
 
     const res = await GET(makeRequest(), makeParams());
 

--- a/__tests__/unit/hooks/fetchImages.test.ts
+++ b/__tests__/unit/hooks/fetchImages.test.ts
@@ -111,6 +111,20 @@ describe("useFetchImages — search mode", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("returns early without calling fetch when searchInput.current is null", async () => {
+    const fetchSpy = jest.spyOn(global, "fetch");
+    
+    const { result } = renderFetchImages({
+      searchInput: { current: null } as RefObject<HTMLInputElement | null>,
+    });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   it("calls setLoading(true) then setLoading(false) on success", async () => {
     mockSuccessFetch();
 
@@ -192,6 +206,20 @@ describe("useFetchImages — random mode", () => {
     const { result } = renderFetchImages({
       isRandom: true,
       searchInput: makeSearchInput(""),
+    });
+
+    await act(async () => {
+      await result.current();
+    });
+
+    expect(fetchSpy.mock.calls[0]?.[0] as string).not.toContain("query=");
+  });
+
+  it("omits query from random URL when searchInput.current is null", async () => {
+    const fetchSpy = mockSuccessFetch({ results: [], total_pages: 0 });
+    const { result } = renderFetchImages({
+      isRandom: true,
+      searchInput: { current: null } as RefObject<HTMLInputElement | null>,
     });
 
     await act(async () => {
@@ -300,6 +328,38 @@ describe("useFetchImages — error handling", () => {
     });
 
     expect(setError).toHaveBeenCalledWith("Unexpected error");
+  });
+
+  it("falls back to generic message when data has no results and no message", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockResolvedValue({}),
+    } as unknown as Response);
+
+    const { result, setError } = renderFetchImages();
+
+    await act(async () => {
+      await result.current("cats");
+    });
+
+    expect(setError).toHaveBeenCalledWith("Unexpected response from the server.");
+  });
+
+  it("calls setError when the success response body cannot be parsed as JSON", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: jest.fn().mockRejectedValue(new Error("Invalid JSON")),
+    } as unknown as Response);
+
+    const { result, setError } = renderFetchImages();
+
+    await act(async () => {
+      await result.current("cats");
+    });
+
+    expect(setError).toHaveBeenCalledWith(
+      "Received an unexpected response from the server.",
+    );
   });
 
   it("swallows AbortError without calling setError or setLoading(false)", async () => {

--- a/__tests__/unit/hooks/fetchImages.test.ts
+++ b/__tests__/unit/hooks/fetchImages.test.ts
@@ -113,7 +113,7 @@ describe("useFetchImages — search mode", () => {
 
   it("returns early without calling fetch when searchInput.current is null", async () => {
     const fetchSpy = jest.spyOn(global, "fetch");
-    
+
     const { result } = renderFetchImages({
       searchInput: { current: null } as RefObject<HTMLInputElement | null>,
     });
@@ -342,7 +342,9 @@ describe("useFetchImages — error handling", () => {
       await result.current("cats");
     });
 
-    expect(setError).toHaveBeenCalledWith("Unexpected response from the server.");
+    expect(setError).toHaveBeenCalledWith(
+      "Unexpected response from the server.",
+    );
   });
 
   it("calls setError when the success response body cannot be parsed as JSON", async () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -65,6 +65,7 @@ function Home() {
   // Resets to page 1 and fetches on form submit.
   const onChange = (event: SyntheticEvent<HTMLFormElement>) => {
     event.preventDefault();
+    /* c8 ignore next -- searchInput ref is always attached when the component is mounted */
     const query = searchInput.current?.value?.trim() ?? "";
 
     if (!query) {
@@ -94,6 +95,7 @@ function Home() {
     setOrderBy("relevance");
     setColor("");
 
+    /* c8 ignore next -- searchInput ref is always attached when the component is mounted */
     if (searchInput.current) {
       searchInput.current.value = "";
     }
@@ -146,6 +148,7 @@ function Home() {
       } else {
         setPage(1);
       }
+      /* c8 ignore next 3 -- searchInput ref is always attached when the component is mounted */
     } else {
       console.error("searchInput ref is not attached to the DOM");
     }

--- a/app/ui/PaginationControls.tsx
+++ b/app/ui/PaginationControls.tsx
@@ -73,6 +73,7 @@ const PaginationControls = ({
           onClick={() =>
             setInputPage((prev) => {
               const n = parseInt(prev, 10);
+              /* c8 ignore next -- button is disabled when n is NaN */
               return String(Math.max(1, isNaN(n) ? 1 : n - 1));
             })
           }

--- a/app/ui/PaginationControls.tsx
+++ b/app/ui/PaginationControls.tsx
@@ -105,6 +105,7 @@ const PaginationControls = ({
           onClick={() =>
             setInputPage((prev) => {
               const n = parseInt(prev, 10);
+              /* c8 ignore next -- button is disabled when n is NaN */
               return String(Math.min(totalPagesMax, isNaN(n) ? 1 : n + 1));
             })
           }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest",
     "test:unit": "jest __tests__/unit",
     "test:components": "jest __tests__/components",
+    "test:integration": "jest __tests__/integration",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
   },


### PR DESCRIPTION
## Summary

- Adds a full integration test suite for the `Home` page component (`__tests__/integration/page.test.tsx`), rendering the real component tree with only `global.fetch` and `window.matchMedia` mocked
- Fills all remaining coverage gaps in the unit and component test suites
- Annotates structurally unreachable branches in source files with `/* c8 ignore */` comments
- Achieves **100% lines, branches, and functions** coverage across the full test suite

## What's included

### New: integration tests (`__tests__/integration/page.test.tsx`)
24 tests covering the full `Home` page, including:
- Initial render (no fetch on mount)
- Successful search: images, pagination display, correct API URL
- Error state, no-results state, loading state (inputs disabled during fetch)
- Filter button, Next/Previous, Go button, per-page selector, language selector, color filter, sort order toggle
- User mode switching (photos, likes, collections)
- Reset via title click
- Random mode
- Page-reset behaviors: searching from page 2, changing per-page on page 2, clicking a filter on page 2
- Dark mode toggle, sort order toggle (both directions)

### New: `test:integration` script in `package.json`

### Unit/component coverage gaps filled
- **API routes** (`images`, `photos/random`, `users/*/photos`, `users/*/likes`, `users/*/collections`): added tests for 401 (key-revoked path + `console.error`) and unknown status codes (418, covers `??` fallback message)
- **`useFetchImages` hook**: added tests for `searchInput.current === null` in search mode, `searchInput.current === null` in random mode, success response with no `results` key and no `message`, and `response.json()` throwing on a successful response
- **`ImageCard`**: added test for `image.color === null` (covers `backgroundColor: undefined` branch)

### Source-file `/* c8 ignore */` annotations
Unreachable defensive branches annotated rather than forced through impossible code paths:
- `app/ui/PaginationControls.tsx`: stepper button `isNaN(n) ? 1` ternaries (buttons are disabled when input is NaN)
- `app/page.tsx`: `searchInput.current` null guards in `onChange`, `handleReset`, and `handleSelection`
