### PR TITLE
Optimize CI workflow for pull requests and add concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,25 @@
 name: CI
 
-# Run on every push and pull request targeting main.
+# Run only on pull requests targeting main.
+# Push to main is omitted -- CI already ran on the PR before merge,
+# so re-running on push is a duplicate that costs extra minutes.
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["main"]
+    # Only run when source code or dependencies change.
+    # Skips CI for docs, config, or workflow-only changes.
+    paths:
+      - "app/**"
+      - "__tests__/**"
+      - "*.ts"
+      - "*.tsx"
+      - "package-lock.json"
+
+# Cancel any in-progress run for the same PR branch when a new commit is pushed.
+# Prevents paying for stale runs that are no longer relevant.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:


### PR DESCRIPTION
This pull request updates the GitHub Actions CI workflow to optimize when and how CI runs. The main improvements are to reduce unnecessary CI runs, save CI minutes, and ensure that only relevant changes trigger builds.

Workflow trigger improvements:

* The CI workflow now only runs on pull requests targeting the `main` branch, and no longer runs on direct pushes to `main`, since CI will already have run on the PR before merge.
* The workflow is further restricted to run only when source code or dependencies change (e.g., files in `app/**`, `__tests__/**`, `*.ts`, `*.tsx`, or `package-lock.json`), skipping CI for changes to docs, config, or workflow files.

Resource usage optimization:

* Added a concurrency group so that when multiple commits are pushed to the same PR branch, any in-progress CI run is cancelled in favor of the latest, preventing duplicate/stale runs and saving CI minutes.Updated CI workflow to run only on pull requests targeting main and added concurrency settings.